### PR TITLE
Bump cheerio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "babylon": "^6.11.4",
     "binary-search": "^1.2.0",
-    "cheerio": "~0.19.0",
+    "cheerio": "0.22.0",
     "lodash": "^4.0.0",
     "pofile": "~1.0.0",
     "typescript": "~2.0.3",


### PR DESCRIPTION
Bump cheerio version so that it uses a secure version of lodash.

See also https://github.com/udemy/website-django/pull/36056.

There are several GitHub security alerts that require lodash^4.17.13:

CVE-2019-10744
CVE-2018-3721
CVE-2019-1010266
CVE-2018-16487